### PR TITLE
Add clipboard manager popup

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,69 @@
+// Background service worker for PII Redactor
+// Handles messages from content scripts and performs PII masking
+
+// Default settings
+const DEFAULT_SETTINGS = {
+  enabled: true,
+  maskEmail: '[EMAIL]',
+  maskPhone: '[PHONE]',
+  maskSSN: '[SSN]'
+};
+
+// Load settings from storage
+async function getSettings() {
+  return new Promise((resolve) => {
+    chrome.storage.sync.get(DEFAULT_SETTINGS, (items) => {
+      resolve(Object.assign({}, DEFAULT_SETTINGS, items));
+    });
+  });
+}
+
+// Regex patterns for common PII
+const EMAIL_REGEX = /[\w.-]+@[\w.-]+\.[A-Za-z]{2,6}/g;
+const PHONE_REGEX = /\b\d{3}[-.\s]?\d{3}[-.\s]?\d{4}\b/g;
+const SSN_REGEX = /\b\d{3}-?\d{2}-?\d{4}\b/g;
+
+const HISTORY_KEY = 'clipboardHistory';
+const HISTORY_LIMIT = 50;
+
+function maskText(text, settings) {
+  if (!text) return text;
+  let result = text;
+  result = result.replace(EMAIL_REGEX, settings.maskEmail);
+  result = result.replace(PHONE_REGEX, settings.maskPhone);
+  result = result.replace(SSN_REGEX, settings.maskSSN);
+  return result;
+}
+
+function addClipboardEntry(text) {
+  chrome.storage.local.get({ [HISTORY_KEY]: [] }, (result) => {
+    const history = result[HISTORY_KEY];
+    history.unshift({ text, time: Date.now() });
+    if (history.length > HISTORY_LIMIT) {
+      history.length = HISTORY_LIMIT;
+    }
+    chrome.storage.local.set({ [HISTORY_KEY]: history });
+  });
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (!message || !message.type) {
+    return;
+  }
+
+  if (message.type === 'mask') {
+    getSettings().then((settings) => {
+      if (!settings.enabled) {
+        sendResponse({ text: message.text });
+        return;
+      }
+      const masked = maskText(message.text, settings);
+      sendResponse({ text: masked });
+    });
+    return true; // asynchronous
+  }
+
+  if (message.type === 'saveClipboard') {
+    addClipboardEntry(message.text);
+  }
+});

--- a/extension/contentScript.js
+++ b/extension/contentScript.js
@@ -1,0 +1,55 @@
+// Content script for PII Redactor
+
+// Helper to send text to background for masking
+function maskText(text) {
+  return new Promise((resolve) => {
+    chrome.runtime.sendMessage({type: 'mask', text}, (response) => {
+      resolve(response ? response.text : text);
+    });
+  });
+}
+
+// Intercept copy events to sanitize clipboard
+function handleCopy(event) {
+  const selection = document.getSelection();
+  if (!selection) return;
+  const text = selection.toString();
+  if (!text) return;
+  event.preventDefault();
+  maskText(text).then((masked) => {
+    event.clipboardData.setData('text/plain', masked);
+    chrome.runtime.sendMessage({ type: 'saveClipboard', text: masked });
+  });
+}
+
+document.addEventListener('copy', handleCopy, true);
+
+// Sanitize text in input fields
+async function sanitizeField(element) {
+  if (!element) return;
+  const value = element.value || element.innerText;
+  const masked = await maskText(value);
+  if (element.value !== undefined) {
+    element.value = masked;
+  } else {
+    element.innerText = masked;
+  }
+}
+
+function handleInput(event) {
+  const element = event.target;
+  if (element.tagName === 'INPUT' || element.tagName === 'TEXTAREA' || element.isContentEditable) {
+    sanitizeField(element);
+  }
+}
+
+document.addEventListener('input', handleInput, true);
+
+// Intercept form submissions to ensure fields are sanitized
+function handleSubmit(event) {
+  const form = event.target;
+  const elements = form.querySelectorAll('input, textarea, [contenteditable="true"]');
+  elements.forEach((el) => sanitizeField(el));
+}
+
+document.addEventListener('submit', handleSubmit, true);

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,28 @@
+{
+  "manifest_version": 3,
+  "name": "PII Redactor",
+  "version": "0.1",
+  "description": "Automatically detects and masks PII in clipboard and text fields before submission.",
+  "permissions": [
+    "storage",
+    "activeTab",
+    "scripting",
+    "clipboardRead",
+    "clipboardWrite"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["contentScript.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "action": {
+    "default_title": "PII Redactor",
+    "default_popup": "popup.html"
+  },
+  "options_page": "options.html"
+}

--- a/extension/options.html
+++ b/extension/options.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>PII Redactor Options</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    label { display: block; margin-bottom: 10px; }
+  </style>
+</head>
+<body>
+  <h1>PII Redactor Options</h1>
+  <label>
+    <input type="checkbox" id="enabled"> Enable redaction
+  </label>
+  <label>
+    Email mask:
+    <input type="text" id="maskEmail">
+  </label>
+  <label>
+    Phone mask:
+    <input type="text" id="maskPhone">
+  </label>
+  <label>
+    SSN mask:
+    <input type="text" id="maskSSN">
+  </label>
+  <button id="save">Save</button>
+  <p id="status"></p>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,0 +1,33 @@
+// Options page script
+
+const DEFAULT_SETTINGS = {
+  enabled: true,
+  maskEmail: '[EMAIL]',
+  maskPhone: '[PHONE]',
+  maskSSN: '[SSN]'
+};
+
+function restoreOptions() {
+  chrome.storage.sync.get(DEFAULT_SETTINGS, (items) => {
+    document.getElementById('enabled').checked = items.enabled;
+    document.getElementById('maskEmail').value = items.maskEmail;
+    document.getElementById('maskPhone').value = items.maskPhone;
+    document.getElementById('maskSSN').value = items.maskSSN;
+  });
+}
+
+document.getElementById('save').addEventListener('click', () => {
+  const settings = {
+    enabled: document.getElementById('enabled').checked,
+    maskEmail: document.getElementById('maskEmail').value,
+    maskPhone: document.getElementById('maskPhone').value,
+    maskSSN: document.getElementById('maskSSN').value
+  };
+  chrome.storage.sync.set(settings, () => {
+    const status = document.getElementById('status');
+    status.textContent = 'Options saved.';
+    setTimeout(() => { status.textContent = ''; }, 1000);
+  });
+});
+
+document.addEventListener('DOMContentLoaded', restoreOptions);

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Clipboard History</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 10px; width: 300px; }
+    ul { list-style: none; padding: 0; }
+    li { margin-bottom: 10px; }
+    textarea { width: 100%; height: 60px; }
+  </style>
+</head>
+<body>
+  <h2>Clipboard History</h2>
+  <ul id="history"></ul>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,50 @@
+const HISTORY_KEY = 'clipboardHistory';
+
+function loadHistory() {
+  chrome.storage.local.get({ [HISTORY_KEY]: [] }, (result) => {
+    const history = result[HISTORY_KEY];
+    const list = document.getElementById('history');
+    list.innerHTML = '';
+    history.forEach((entry, index) => {
+      const li = document.createElement('li');
+      const textarea = document.createElement('textarea');
+      textarea.value = entry.text;
+      li.appendChild(textarea);
+      const save = document.createElement('button');
+      save.textContent = 'Save';
+      save.addEventListener('click', () => {
+        updateEntry(index, textarea.value);
+      });
+      const del = document.createElement('button');
+      del.textContent = 'Delete';
+      del.addEventListener('click', () => {
+        deleteEntry(index);
+      });
+      li.appendChild(save);
+      li.appendChild(del);
+      list.appendChild(li);
+    });
+  });
+}
+
+function updateEntry(index, text) {
+  chrome.storage.local.get({ [HISTORY_KEY]: [] }, (result) => {
+    const history = result[HISTORY_KEY];
+    if (index < history.length) {
+      history[index].text = text;
+      chrome.storage.local.set({ [HISTORY_KEY]: history }, loadHistory);
+    }
+  });
+}
+
+function deleteEntry(index) {
+  chrome.storage.local.get({ [HISTORY_KEY]: [] }, (result) => {
+    const history = result[HISTORY_KEY];
+    if (index < history.length) {
+      history.splice(index, 1);
+      chrome.storage.local.set({ [HISTORY_KEY]: history }, loadHistory);
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', loadHistory);

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,19 @@
+# PII Redactor Chrome Extension
 
+This extension automatically detects and masks common personally identifiable information (PII) in clipboard contents and text input fields before it can be submitted.
+
+## Features
+- Replaces email addresses, phone numbers, and Social Security numbers with placeholders.
+- Sanitizes text copied to the clipboard.
+- Sanitizes text as you type or paste into input fields and before form submission.
+- Simple options page for enabling/disabling the extension and customizing placeholder text.
+- Popup clipboard manager shows masked clipboard history with options to edit or delete entries.
+
+## Development
+1. Open Chrome and navigate to `chrome://extensions`.
+2. Enable **Developer mode**.
+3. Click **Load unpacked** and select the `extension` folder in this repository.
+4. Adjust options via the extension's options page if needed.
+5. Click the extension icon to open the clipboard manager popup.
+
+All processing happens locally in the browser.


### PR DESCRIPTION
## Summary
- save masked clipboard text to storage from content script
- manage clipboard history in background service worker
- add popup UI with list of clipboard entries
- launch popup from extension icon via manifest
- document popup in README

## Testing
- `npm --version`
