### PR TITLE
Add history repository and VM with virtualization

### DIFF
--- a/src/PIIRedactorApp/Models/HistoryEntry.cs
+++ b/src/PIIRedactorApp/Models/HistoryEntry.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace PIIRedactorApp.Models
+{
+    public class HistoryEntry
+    {
+        public DateTime Timestamp { get; set; }
+        public string Text { get; set; } = string.Empty;
+    }
+}

--- a/src/PIIRedactorApp/Services/HistoryRepository.cs
+++ b/src/PIIRedactorApp/Services/HistoryRepository.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using PIIRedactorApp.Models;
+
+namespace PIIRedactorApp.Services
+{
+    public class HistoryRepository
+    {
+        private readonly string path;
+
+        public HistoryRepository(string path)
+        {
+            this.path = path;
+            var dir = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+            if (!File.Exists(path))
+            {
+                File.Create(path).Dispose();
+            }
+        }
+
+        public void Add(string text)
+        {
+            var entry = new HistoryEntry
+            {
+                Timestamp = DateTime.UtcNow,
+                Text = text
+            };
+            var json = JsonSerializer.Serialize(entry);
+            File.AppendAllText(path, json + Environment.NewLine);
+        }
+
+        public IEnumerable<HistoryEntry> LoadLatestEntries(int count)
+        {
+            var queue = new Queue<string>();
+            foreach (var line in File.ReadLines(path))
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                    continue;
+                queue.Enqueue(line);
+                if (queue.Count > count)
+                    queue.Dequeue();
+            }
+
+            foreach (var line in queue)
+            {
+                var entry = JsonSerializer.Deserialize<HistoryEntry>(line);
+                if (entry != null)
+                    yield return entry;
+            }
+        }
+    }
+}

--- a/src/PIIRedactorApp/ViewModels/MainViewModel.cs
+++ b/src/PIIRedactorApp/ViewModels/MainViewModel.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using PIIRedactorApp.Models;
+using PIIRedactorApp.Services;
+
+namespace PIIRedactorApp.ViewModels
+{
+    public class MainViewModel
+    {
+        private const int MaxItemsInMemory = 100;
+        private readonly ClipboardService clipboardService;
+        private readonly HistoryRepository repository;
+
+        public ObservableCollection<HistoryEntry> ClipboardHistory { get; } = new();
+
+        public MainViewModel()
+        {
+            clipboardService = new ClipboardService();
+            repository = new HistoryRepository(Path.Combine(AppContext.BaseDirectory, "history.json"));
+
+            foreach (var entry in repository.LoadLatestEntries(MaxItemsInMemory))
+            {
+                ClipboardHistory.Insert(0, entry);
+            }
+
+            clipboardService.ClipboardChanged += OnClipboardChanged;
+        }
+
+        private void OnClipboardChanged(object? sender, string text)
+        {
+            repository.Add(text);
+            ClipboardHistory.Insert(0, new HistoryEntry { Timestamp = DateTime.UtcNow, Text = text });
+            while (ClipboardHistory.Count > MaxItemsInMemory)
+            {
+                ClipboardHistory.RemoveAt(ClipboardHistory.Count - 1);
+            }
+        }
+
+        public RedactorConfig Config
+        {
+            get => clipboardService.Config;
+            set => clipboardService.Config = value;
+        }
+    }
+}

--- a/src/PIIRedactorApp/Views/MainWindow.xaml
+++ b/src/PIIRedactorApp/Views/MainWindow.xaml
@@ -5,7 +5,21 @@
     <Grid>
         <StackPanel>
             <Button Content="Settings" Click="Settings_Click" HorizontalAlignment="Right" Width="75" Margin="0,5"/>
-            <ListBox Name="ClipboardList" Height="250"/>
+            <ListBox Name="ClipboardList"
+                     ItemsSource="{Binding ClipboardHistory}"
+                     Height="250"
+                     ScrollViewer.CanContentScroll="True"
+                     VirtualizingPanel.IsVirtualizing="True"
+                     VirtualizingPanel.VirtualizationMode="Recycling">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel>
+                            <TextBlock Text="{Binding Text}"/>
+                            <TextBlock Text="{Binding Timestamp}" FontSize="10" Foreground="Gray"/>
+                        </StackPanel>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
         </StackPanel>
     </Grid>
 </Window>

--- a/src/PIIRedactorApp/Views/MainWindow.xaml.cs
+++ b/src/PIIRedactorApp/Views/MainWindow.xaml.cs
@@ -1,35 +1,25 @@
-using System.Collections.ObjectModel;
 using System.Windows;
-using System.Windows.Threading;
+using PIIRedactorApp.ViewModels;
 
 namespace PIIRedactorApp.Views
 {
     public partial class MainWindow : Window
     {
-        private readonly ClipboardService clipboardService;
-        public ObservableCollection<string> ClipboardHistory { get; } = new();
+        private readonly MainViewModel viewModel;
 
         public MainWindow()
         {
             InitializeComponent();
-            clipboardService = new ClipboardService();
-            clipboardService.ClipboardChanged += OnClipboardChanged;
-        }
-
-        private void OnClipboardChanged(object sender, string text)
-        {
-            Dispatcher.Invoke(() => {
-                ClipboardHistory.Insert(0, text);
-                ClipboardList.ItemsSource = ClipboardHistory;
-            });
+            viewModel = new MainViewModel();
+            DataContext = viewModel;
         }
 
         private void Settings_Click(object sender, RoutedEventArgs e)
         {
-            var win = new SettingsWindow(clipboardService.Config);
+            var win = new SettingsWindow(viewModel.Config);
             if (win.ShowDialog() == true)
             {
-                clipboardService.Config = win.Config;
+                viewModel.Config = win.Config;
             }
         }
     }


### PR DESCRIPTION
## Summary
- persist clipboard entries in `HistoryRepository`
- add a `MainViewModel` that loads history lazily and keeps only recent items in memory
- bind `MainWindow` to the view model and add UI virtualization

## Testing
- `dotnet build` *(fails: command not found)*