### PR TITLE
Introduce MVVM and MaterialDesign theme

### DIFF
--- a/src/PIIRedactorApp/App.xaml
+++ b/src/PIIRedactorApp/App.xaml
@@ -3,5 +3,13 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              StartupUri="Views/MainWindow.xaml">
     <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.DeepPurple.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/PIIRedactorApp/PIIRedactorApp.csproj
+++ b/src/PIIRedactorApp/PIIRedactorApp.csproj
@@ -6,5 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ML" Version="2.0.0" />
+    <PackageReference Include="MaterialDesignThemes" Version="4.7.0" />
+    <PackageReference Include="MaterialDesignColors" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/src/PIIRedactorApp/Services/ClipboardService.cs
+++ b/src/PIIRedactorApp/Services/ClipboardService.cs
@@ -5,7 +5,7 @@ using Microsoft.ML;
 using PIIRedactorApp.Models;
 using System.Windows.Threading;
 
-namespace PIIRedactorApp
+namespace PIIRedactorApp.Services
 {
     public class ClipboardService
     {

--- a/src/PIIRedactorApp/ViewModels/MainViewModel.cs
+++ b/src/PIIRedactorApp/ViewModels/MainViewModel.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Input;
+using PIIRedactorApp.Services;
+using PIIRedactorApp.Views;
+
+namespace PIIRedactorApp.ViewModels
+{
+    public class ClipboardItem
+    {
+        public string Text { get; set; } = string.Empty;
+        public DateTime Time { get; set; }
+    }
+
+    public class RelayCommand<T> : ICommand
+    {
+        private readonly Action<T?> _execute;
+        private readonly Predicate<T?>? _canExecute;
+
+        public RelayCommand(Action<T?> execute, Predicate<T?>? canExecute = null)
+        {
+            _execute = execute;
+            _canExecute = canExecute;
+        }
+
+        public bool CanExecute(object? parameter)
+        {
+            return _canExecute == null || _canExecute((T?)parameter);
+        }
+
+        public void Execute(object? parameter)
+        {
+            _execute((T?)parameter);
+        }
+
+        public event EventHandler? CanExecuteChanged
+        {
+            add { CommandManager.RequerySuggested += value; }
+            remove { CommandManager.RequerySuggested -= value; }
+        }
+    }
+
+    public class RelayCommand : ICommand
+    {
+        private readonly Action _execute;
+        private readonly Func<bool>? _canExecute;
+
+        public RelayCommand(Action execute, Func<bool>? canExecute = null)
+        {
+            _execute = execute;
+            _canExecute = canExecute;
+        }
+
+        public bool CanExecute(object? parameter) => _canExecute?.Invoke() ?? true;
+
+        public void Execute(object? parameter) => _execute();
+
+        public event EventHandler? CanExecuteChanged
+        {
+            add { CommandManager.RequerySuggested += value; }
+            remove { CommandManager.RequerySuggested -= value; }
+        }
+    }
+
+    public class MainViewModel : INotifyPropertyChanged
+    {
+        private readonly ClipboardService _service;
+
+        public ObservableCollection<ClipboardItem> ClipboardHistory { get; } = new();
+
+        public ICommand CopyCommand { get; }
+        public ICommand DeleteCommand { get; }
+        public ICommand OpenSettingsCommand { get; }
+
+        public MainViewModel()
+        {
+            _service = new ClipboardService();
+            _service.ClipboardChanged += Service_ClipboardChanged;
+
+            CopyCommand = new RelayCommand<ClipboardItem>(CopyItem);
+            DeleteCommand = new RelayCommand<ClipboardItem>(DeleteItem);
+            OpenSettingsCommand = new RelayCommand(OpenSettings);
+        }
+
+        private void Service_ClipboardChanged(object? sender, string text)
+        {
+            Application.Current.Dispatcher.Invoke(() =>
+            {
+                ClipboardHistory.Insert(0, new ClipboardItem
+                {
+                    Text = text,
+                    Time = DateTime.Now
+                });
+            });
+        }
+
+        private void CopyItem(ClipboardItem? item)
+        {
+            if (item != null)
+            {
+                Clipboard.SetText(item.Text);
+            }
+        }
+
+        private void DeleteItem(ClipboardItem? item)
+        {
+            if (item != null)
+            {
+                ClipboardHistory.Remove(item);
+            }
+        }
+
+        private void OpenSettings()
+        {
+            var win = new SettingsWindow(_service.Config);
+            if (win.ShowDialog() == true)
+            {
+                _service.Config = win.Config;
+            }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+    }
+}

--- a/src/PIIRedactorApp/Views/MainWindow.xaml
+++ b/src/PIIRedactorApp/Views/MainWindow.xaml
@@ -1,11 +1,37 @@
 <Window x:Class="PIIRedactorApp.Views.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="PII Redactor Clipboard Manager" Height="350" Width="525">
-    <Grid>
-        <StackPanel>
-            <Button Content="Settings" Click="Settings_Click" HorizontalAlignment="Right" Width="75" Margin="0,5"/>
-            <ListBox Name="ClipboardList" Height="250"/>
-        </StackPanel>
+        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+        Title="PII Redactor Clipboard Manager"
+        Style="{DynamicResource MaterialDesignWindow}"
+        Height="400" Width="600">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Button Content="Settings"
+                Command="{Binding OpenSettingsCommand}"
+                HorizontalAlignment="Right" Width="90" Margin="0,0,0,5"/>
+        <DataGrid Grid.Row="1"
+                  ItemsSource="{Binding ClipboardHistory}"
+                  AutoGenerateColumns="False"
+                  VirtualizingPanel.IsVirtualizing="True"
+                  VirtualizingPanel.VirtualizationMode="Recycling">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Text" Binding="{Binding Text}" Width="*"/>
+                <DataGridTextColumn Header="Time" Binding="{Binding Time}" Width="150"/>
+                <DataGridTemplateColumn Header="Actions" Width="120">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Content="Copy" Command="{Binding DataContext.CopyCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="{Binding}" Margin="0,0,5,0" />
+                                <Button Content="Delete" Command="{Binding DataContext.DeleteCommand, RelativeSource={RelativeSource AncestorType=Window}}" CommandParameter="{Binding}" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+            </DataGrid.Columns>
+        </DataGrid>
     </Grid>
 </Window>

--- a/src/PIIRedactorApp/Views/MainWindow.xaml.cs
+++ b/src/PIIRedactorApp/Views/MainWindow.xaml.cs
@@ -1,36 +1,15 @@
-using System.Collections.ObjectModel;
 using System.Windows;
-using System.Windows.Threading;
+using PIIRedactorApp.ViewModels;
 
 namespace PIIRedactorApp.Views
 {
     public partial class MainWindow : Window
     {
-        private readonly ClipboardService clipboardService;
-        public ObservableCollection<string> ClipboardHistory { get; } = new();
-
         public MainWindow()
         {
             InitializeComponent();
-            clipboardService = new ClipboardService();
-            clipboardService.ClipboardChanged += OnClipboardChanged;
+            DataContext = new MainViewModel();
         }
 
-        private void OnClipboardChanged(object sender, string text)
-        {
-            Dispatcher.Invoke(() => {
-                ClipboardHistory.Insert(0, text);
-                ClipboardList.ItemsSource = ClipboardHistory;
-            });
-        }
-
-        private void Settings_Click(object sender, RoutedEventArgs e)
-        {
-            var win = new SettingsWindow(clipboardService.Config);
-            if (win.ShowDialog() == true)
-            {
-                clipboardService.Config = win.Config;
-            }
-        }
     }
 }


### PR DESCRIPTION
## Summary
- add `MainViewModel` with clipboard commands and history
- switch clipboard service namespace to `PIIRedactorApp.Services`
- bind `MainWindow` to the view model and use a `DataGrid`
- apply a MaterialDesign theme
- update project references for MaterialDesign packages

## Testing
- `dotnet --version` *(fails: command not found)*